### PR TITLE
Fixed crashing when asking for proxy file.

### DIFF
--- a/MSMC_Linux.py
+++ b/MSMC_Linux.py
@@ -505,7 +505,7 @@ def Load():
 
 def Proxys():
     global proxylist
-    fileNameProxy = filedialog.askopenfile(mode='rb', title='Choose a Proxy file',filetype=(("txt", "*.txt"), ("All files", "*.txt")))
+    fileNameProxy = filedialog.askopenfile(mode='rb', title='Choose a Proxy file',filetypes=(("txt", "*.txt"), ("All files", "*.txt")))
     if fileNameProxy is None:
         print(Fore.LIGHTRED_EX+"Invalid File.")
         time.sleep(2)


### PR DESCRIPTION
For some reason, the parameter was filetype, it's supposed to be filetypes, hence causing a crash when trying to select the proxy file.